### PR TITLE
Purple outline

### DIFF
--- a/mod/HidePlayers/gui/shared/portraits.gui
+++ b/mod/HidePlayers/gui/shared/portraits.gui
@@ -1,0 +1,2140 @@
+######################################################
+################## PORTRAIT TYPES ####################
+######################################################
+
+types PortraitTypes
+{
+
+    ####################################
+    ######### MAIN PORTRAITS ###########
+    ####################################
+
+    # The standard portrait types. CoA, opinion and status icons are included by default; use blockovveride to disable them.
+
+    ## Extra small head portrait. These are smaller than we would like, so only use if you really, really have to.
+    type portrait_head_small = widget {
+        size = { 85 90 }
+
+        background = {
+            using = Background_Area_Solid
+
+            modify_texture = {
+                texture = "gfx/interface/component_masks/mask_fade_vertical.dds"
+                blend_mode = alphamultiply
+                alpha = 0.2
+                mirror = vertical
+            }
+        }
+
+        background = {
+            block "empty_character" {}
+            visible = "[Not( Character.HasLandedTitles )]"
+            texture = "gfx/portraits/portrait_frame.dds"
+            using = Color_Grey
+            margin = { -4 -4 }
+            alpha = 0.4
+        }
+
+        widget = {
+            size = { 100% 100% }
+            using = Portrait_Background_Glows
+
+            block "empty_character" {}
+        }
+
+        portrait_button = {
+            parentanchor = bottom|hcenter
+            size = { 80 100 }
+            using = portrait_base
+
+            block "portrait_texture"
+            {
+                portrait_texture = "[Character.GetPortrait('environment_head', 'camera_head', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+            }
+
+            mask = "gfx/portraits/portrait_mask_head_small.dds"
+            effectname = "NoHighlight"
+
+            highlight_icon = {
+                name = "prison_bars"
+                visible = "[Character.IsImprisoned]"
+                size = { 80 88 }
+                parentanchor = bottom
+                effectname = "NoHighlight"
+                texture = "gfx/portraits/portrait_prison_head.dds"
+
+                modify_texture = {
+                    name = "mask"
+                    texture = "gfx/portraits/portrait_mask_head_small.dds"
+                    spriteType = Corneredstretched
+                    blend_mode = alphamultiply
+                }
+            }
+
+            block "portrait_button" {}
+        }
+
+        widget = {
+            name = "character_rank"
+            visible = "[Character.HasLandedTitles]"
+            size = { 100% 100% }
+
+            background = {
+                texture = "gfx/portraits/portrait_rank.dds"
+
+                margin_top = -4
+                margin_bottom = -3
+                margin_right = -4
+                margin_left = -3
+
+                framesize = { 196 194 }
+                frame = "[Character.GetPrimaryTitle.GetTierFrame]"
+            }
+        }
+
+        block "coa" {
+            coa_realm_tiny = {
+                visible = "[Character.HasLandedTitles]"
+                parentanchor = bottom|left
+                position = { 3 -2 }
+                scale = 0.85
+            }
+        }
+
+        widget = {
+            size = { 100% 100% }
+            visible = "[Not( Character.HasLandedTitles )]"
+            block "empty_character" {}
+
+            background = {
+                texture = "gfx/portraits/portrait_frame.dds"
+                using = Color_Grey
+                margin = { -4 -4 }
+                alpha = 0.4
+
+                modify_texture = {
+                    texture = "gfx/interface/component_masks/mask_fade_vertical.dds"
+                    blend_mode = alphamultiply
+                    mirror = vertical
+                }
+            }
+
+            background = {
+                visible = "[Character.IsHovered]"
+                texture = "gfx/portraits/portrait_frame.dds"
+                using = Color_Grey
+                alpha = 0.7
+                margin = { -4 -4 }
+            }
+        }
+
+        flowcontainer = {
+            parentanchor = bottom|right
+            ignoreinvisible = yes
+            direction = vertical
+            margin = { 4 0 }
+            margin_bottom = 5
+
+            portrait_status_icons_small = {
+                parentanchor = right
+            }
+
+            block "opinion_box"
+            {
+                portrait_opinion_small = {
+                    name = "tutorial_highlight_character_view_opinion_heir"
+                }
+            }
+        }
+
+
+        # Portrait unknown glow
+        highlight_icon = {
+            name = "portrait_unknown_head_small_glow"
+            parentanchor = center
+            position = { 3 -9 }
+            gfxtype = framedbuttongfx
+            effectname = "NoHighlight"
+            texture = "gfx/portraits/unknown_portraits/button_unknown_head.dds"
+            size = { 80 100 }
+            framesize = { 384 480 }
+            upframe = 1
+            overframe = 2
+            block "glow_visible" {
+
+                visible = "[Not(Character.IsValid)]"
+            }
+
+            block "glow_flip" {}
+
+            block "onclick" {}
+        }
+    }
+
+    ## Standard head portrait
+    type portrait_head = widget {
+        size = { 110 120 }
+
+        background = {
+            using = Background_Area_Solid
+        }
+
+        widget = {
+            size = { 100% 100% }
+            using = Portrait_Background_Glows
+
+            block "empty_character" {}
+        }
+
+        portrait_button = {
+            parentanchor = bottom|hcenter
+            size = { 100 125 }
+            using = portrait_base
+
+            block "portrait_texture" {
+                portrait_texture = "[Character.GetPortrait('environment_head', 'camera_head', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+            }
+
+            mask = "gfx/portraits/portrait_mask_head.dds"
+            effectname = "NoHighlight"
+
+            highlight_icon = {
+                name = "prison_bars"
+                visible = "[Character.IsImprisoned]"
+                size = { 100 118 }
+                parentanchor = bottom
+                effectname = "NoHighlight"
+                texture = "gfx/portraits/portrait_prison_head.dds"
+
+                modify_texture = {
+                    name = "mask"
+                    texture = "gfx/portraits/portrait_mask_head.dds"
+                    spriteType = Corneredstretched
+                    blend_mode = alphamultiply
+                }
+            }
+
+            block "portrait_button" {}
+        }
+
+        widget = {
+            visible = "[Character.HasLandedTitles]"
+            size = { 100% 100% }
+
+            background = {
+                texture = "gfx/portraits/portrait_rank.dds"
+
+                margin_bottom = -3
+                margin_top = -4
+                margin_left = -4
+                margin_right = -5
+
+                framesize = { 196 194 }
+                frame = "[Character.GetPrimaryTitle.GetTierFrame]"
+            }
+        }
+
+        portrait_status_icons_small = {
+            parentanchor = bottom|right
+            position = { -7 -8 }
+        }
+
+        block "coa" {
+            coa_realm_tiny = {
+                visible = "[Character.HasLandedTitles]"
+                parentanchor = bottom|left
+                position = { 3 -2 }
+            }
+        }
+
+        block "opinion_box"
+        {
+            portrait_opinion = {
+                parentanchor = bottom|hcenter
+                position = { 1 -4 }
+            }
+        }
+
+        widget = {
+            visible = "[Not( Character.HasLandedTitles )]"
+            size = { 100% 100%}
+
+            background = {
+                texture = "gfx/portraits/portrait_frame.dds"
+                using = Color_Grey
+                margin = { -4 -4 }
+                alpha = 0.5
+            }
+
+            background = {
+                visible = "[Character.IsHovered]"
+                texture = "gfx/portraits/portrait_frame.dds"
+                using = Color_Grey
+                alpha = 0.7
+                margin = { -4 -4 }
+            }
+        }
+
+
+        #portrait unknown glow
+        button = {
+            name = "portrait_unknown_head_glow"
+            parentanchor = center
+            position = { 3 -7 }
+            gfxtype = framedbuttongfx
+            effectname = "NoHighlight"
+            texture = "gfx/portraits/unknown_portraits/button_unknown_head.dds"
+            size = { 98 125 }
+            framesize = { 384 480 }
+            upframe = 1
+            overframe = 2
+
+            block "glow_visible" {
+                visible = "[Not(Character.IsValid)]"
+            }
+
+            block "glow_flip" {}
+
+            block "onclick" {}
+
+        }
+    }
+
+    ## Standard portrait from shoulders up
+    type portrait_shoulders = widget {
+        size = { 125 160 }
+
+        widget = {
+            size = { 100% 100% }
+            block "portrait_glows"
+            {
+                using = Portrait_Background_Glows
+            }
+        }
+
+        portrait_button = {
+            parentanchor = bottom|hcenter
+            size = { 145 175 }
+            using = portrait_base
+
+            block "portrait_texture"
+            {
+                portrait_texture = "[Character.GetPortrait('environment_shoulders', 'camera_shoulders', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+            }
+
+            mask = "gfx/portraits/portrait_mask_shoulders.dds"
+            effectname = "NoHighlight"
+
+            highlight_icon = {
+                name = "prison_bars"
+                visible = "[Character.IsImprisoned]"
+                size = { 100% 100% }
+                effectname = "NoHighlight"
+                texture = "gfx/portraits/portrait_prison_shoulders.dds"
+
+                modify_texture = {
+                    name = "mask"
+                    texture = "gfx/portraits/portrait_mask_shoulders.dds"
+                    spriteType = Corneredstretched
+                    blend_mode = alphamultiply
+                }
+            }
+
+            block "portrait_button" {}
+        }
+
+        portrait_status_icons = {
+            parentanchor = bottom|right
+            position = { 0 -3 }
+            scale = 0.85
+
+            background = {
+                using = Background_Area_Dark
+                margin = { 2 3 }
+                alpha = 0.8
+            }
+        }
+
+        block "coa" {
+            coa_realm_small_crown = {
+                visible = "[Character.HasLandedTitles]"
+                parentanchor = bottom|left
+                position = { -5 3 }
+            }
+        }
+
+        block "opinion_box"
+        {
+            portrait_opinion = {
+                parentanchor = bottom|hcenter
+                position = { 0 -2 }
+            }
+        }
+
+        #portrait unknown glow
+        button = {
+            position = { -8 -14 }
+            size = { 141 174 }
+            texture = "gfx/portraits/unknown_portraits/button_unknown_shoulders.dds"
+            framesize = { 471 589 }
+            gfxtype = framedbuttongfx
+            effectname = "NoHighlight"
+            upframe = 1
+            overframe = 2
+
+            block "glow_visible" {
+
+                visible = "[Not(Character.IsValid)]"
+
+            }
+
+            block "glow_flip" {}
+
+            block "onclick" {}
+        }
+    }
+
+    ## Standard torso from waist up
+    type portrait_torso = widget {
+        size = { 165 200 }
+
+        widget = {
+            size = { 100% 100% }
+            using = Portrait_Background_Glows
+        }
+
+        portrait_button = {
+            parentanchor = bottom|hcenter
+            size = { 195 225 }
+            using = portrait_base
+
+            block "portrait_texture"
+            {
+                portrait_texture = "[Character.GetPortrait('environment_torso', 'camera_torso', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+            }
+            mask = "gfx/portraits/portrait_mask_torso.dds"
+            effectname = "NoHighlight"
+
+            highlight_icon = {
+                name = "prison_bars"
+                visible = "[Character.IsImprisoned]"
+                size = { 100% 100% }
+                effectname = "NoHighlight"
+                texture = "gfx/portraits/portrait_prison_torso.dds"
+
+                modify_texture = {
+                    name = "mask"
+                    texture = "gfx/portraits/portrait_mask_torso.dds"
+                    spriteType = Corneredstretched
+                    blend_mode = alphamultiply
+                }
+            }
+
+            block "portrait_button" {}
+        }
+
+        portrait_status_icons = {
+            parentanchor = bottom|left
+            position = { 43 -6 }
+            scale = 0.85
+
+            background = {
+                using = Background_Area_Dark
+                margin = { 2 3 }
+                alpha = 0.8
+            }
+        }
+
+        block "coa" {
+            coa_realm_small_crown = {
+                visible = "[Character.HasLandedTitles]"
+                parentanchor = bottom|left
+                position = { -2 1 }
+            }
+        }
+
+        block "opinion_box"
+        {
+            portrait_opinion = {
+                parentanchor = bottom|hcenter
+                position = { 4 -2 }
+            }
+        }
+
+        #portrait unknown glow
+        button = {
+            name = "portrait_unknown_torso_glow"
+            parentanchor = center
+            position = { 0 -12 }
+            gfxtype = framedbuttongfx
+            effectname = "NoHighlight"
+            texture = "gfx/portraits/unknown_portraits/button_unknown.dds"
+            size = { 195 225 }
+            framesize = { 554 780 }
+            upframe = 1
+            overframe = 2
+
+            block "glow_visible" {
+
+                visible = "[Not(Character.IsValid)]"
+
+            }
+
+            block "glow_flip" {}
+
+            block "onclick" {}
+        }
+    }
+
+    ## Standard full body portrait
+    type portrait_body = widget {
+        size = { 210 300 }
+
+        widget = {
+            size = { 100% 100% }
+            using = Portrait_Background_Glows
+        }
+
+        portrait_button = {
+            parentanchor = bottom|hcenter
+            size = { 240 330 }
+            using = portrait_base
+
+            block "portrait_texture" {
+                portrait_texture = "[Character.GetPortrait('environment_body', 'camera_body', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+            }
+            block "mask" {
+                mask = "gfx/portraits/portrait_mask_body.dds"
+            }
+            effectname = "NoHighlight"
+
+            block "prison" {
+                highlight_icon = {
+                    name = "prison_bars"
+                    visible = "[Character.IsImprisoned]"
+                    size = { 100% 100% }
+                    effectname = "NoHighlight"
+                    texture = "gfx/portraits/portrait_prison_body.dds"
+
+                    modify_texture = {
+                        name = "mask"
+                        texture = "gfx/portraits/portrait_mask_body.dds"
+                        spriteType = Corneredstretched
+                        blend_mode = alphamultiply
+                    }
+                }
+            }
+
+            block "portrait_button" {}
+        }
+
+        portrait_status_icons = {
+            parentanchor = bottom|left
+            position = { 60 -5 }
+            scale = 0.85
+
+            background = {
+                using = Background_Area_Dark
+                margin = { 3 3 }
+                alpha = 0.8
+            }
+        }
+
+        block "coa" {
+            coa_realm_medium_crown = {
+                visible = "[Character.HasLandedTitles]"
+                parentanchor = bottom|left
+                position = { -2 4 }
+            }
+        }
+
+        block "opinion_box"
+        {
+            portrait_opinion = {
+                parentanchor = bottom|hcenter
+                block "position_portrait_opinion_body" {
+                    position = { 0 -2 }
+                }
+            }
+        }
+
+        #portrait unknown glow
+        button = {
+            name = "portrait_unknown_body_glow"
+            parentanchor = center
+            position = { 0 -15 }
+            gfxtype = framedbuttongfx
+            effectname = "NoHighlight"
+            texture = "gfx/portraits/unknown_portraits/button_unknown_small.dds"
+            size = { 240 330 }
+            framesize = { 564 780 }
+            upframe = 1
+            overframe = 2
+
+            block "glow_visible" {
+
+                visible = "[Not(Character.IsValid)]"
+
+            }
+
+            block "glow_flip" {}
+
+            block "onclick" {}
+
+        }
+    }
+
+    ####################################
+    ######## SPECIAL PORTRAITS #########
+    ####################################
+
+    type portrait_map = widget {
+        size = { 85 90 }
+
+        portrait_button = {
+            visible = "[Not(Character.IsImprisoned)]"
+            parentanchor = bottom|hcenter
+            size = { 80 100 }
+            using = portrait_base
+            portrait_texture = "[Character.GetPortrait('environment_head', 'camera_head', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+            mask = "gfx/portraits/portrait_mask_head.dds"
+            effectname = "NoHighlight"
+
+            block "portrait_button" {}
+        }
+    }
+
+    type portrait_character_view_main = margin_widget {
+        size = { 300 300 }
+        margin = { 3 3 }
+
+        widget = {
+            size = { 100% 100% }
+            using = Portrait_Background_Glows
+        }
+
+        blockoverride "glow_local_player" {}
+        blockoverride "glow_selected" {}
+        blockoverride "grayscale" {}
+
+        portrait_button = {
+            size = { 300 421 }
+            position = { -30 10 }
+            parentanchor = bottom|hcenter
+            using = portrait_base
+
+            portrait_texture = "[Character.GetAnimatedPortrait(Illustration.GetEnvironment(Character.Self), 'camera_character_view_main', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+            mask = "gfx/portraits/portrait_mask_character_view.dds"
+            effectname = "NoHighlight"
+
+            highlight_icon = {
+                name = "prison_bars"
+                visible = "[Character.IsImprisoned]"
+                size = { 100% 100% }
+                position = { 0 20 }
+
+                effectname = "NoHighlight"
+                texture = "gfx/portraits/portrait_prison_character_view.dds"
+
+                modify_texture = {
+                    name = "mask"
+                    texture = "gfx/portraits/portrait_mask_character_view.dds"
+                    spriteType = Corneredstretched
+                    blend_mode = alphamultiply
+                }
+            }
+
+            block "portrait_button" {}
+        }
+
+        portrait_status_icons = {
+            parentanchor = bottom|right
+            position = { -60 0 }
+
+            block "portrait_status_icons" {}
+        }
+
+        block "opinion_box"
+        {
+            portrait_opinion = {
+                position = { -20 -5 }
+                parentanchor = bottom|hcenter
+
+                block "portrait_opinion" {}
+            }
+        }
+    }
+
+    type portrait_character_view_spouse = margin_widget {
+        size = { 300 300 }
+        margin = { 3 3 }
+
+        widget = {
+            size = { 100% 100% }
+            using = Portrait_Background_Glows
+        }
+
+        portrait_button = {
+            size = { 350 338 }
+            position = { 0 10 }
+            parentanchor = bottom|hcenter
+            using = portrait_base
+
+            portrait_texture = "[Character.GetAnimatedPortrait(Illustration.GetEnvironment( Character.Self ), 'camera_character_view_spouse', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+            mask = "gfx/portraits/portrait_mask_character_view.dds"
+            effectname = "NoHighlight"
+
+            highlight_icon = {
+                name = "prison_bars"
+                visible = "[Character.IsImprisoned]"
+                size = { 100% 100% }
+                position = { 0 20 }
+
+                effectname = "NoHighlight"
+                texture = "gfx/portraits/portrait_prison_character_view.dds"
+
+                modify_texture = {
+                    name = "mask"
+                    texture = "gfx/portraits/portrait_mask_character_view.dds"
+                    spriteType = Corneredstretched
+                    blend_mode = alphamultiply
+                }
+            }
+
+            block "portrait_button" {}
+        }
+
+        # flowcontainer = {
+        #     parentanchor = bottom|right
+        #     widgetanchor = bottom|left
+        #     position = { -18 0 }
+        #     ignoreinvisible = yes
+        #     margin_top = 5
+
+        #     coa_realm_small = {
+        #         visible = "[Character.HasLandedTitles]"
+
+        #         using = Animation_ShowHide_Standard
+        #     }
+
+        #     portrait_status_icons = {
+        #         parentanchor = bottom
+        #     }
+        # }
+
+        # block "opinion_box"
+        # {
+        #   portrait_opinion = {
+        #       position = { 5 -25 }
+        #       parentanchor = bottom|hcenter
+
+        #       block "portrait_opinion" {}
+        #    }
+        # }
+    }
+
+    type portrait_event = widget {
+
+        widget = {
+            size = { 500 490 }
+            parentanchor = bottom
+
+            icon = {
+                name = "hovered"
+                parentanchor = bottom|hcenter
+                size = { 70% 95% }
+                color = { 0.9 0.8 0.6 0.6 }
+
+                using = Background_Portrait_Glow
+
+                block "highlight_visible" {
+                    visible = no
+                }
+
+                state = {
+                    name = _show
+                    duration = 0.1
+                    using = Animation_Curve_Default
+                    alpha = 1
+                }
+
+                state = {
+                    name = _hide
+                    duration = 0.3
+                    using = Animation_Curve_Default
+                    alpha = 0
+                    delay = 0.05
+                }
+            }
+
+            portrait_button = {
+                size = { 500 558 }
+                using = portrait_base
+                parentanchor = hcenter|bottom
+
+                portrait_texture = "[Character.GetAnimatedPortrait('environment_event_standard', 'environment_event_standard', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+                background_texture = "gfx/portraits/portrait_transparent.dds"
+                texture = "gfx/portraits/portrait_transparent.dds"
+                mask = "gfx/portraits/portrait_mask_event.dds"
+                effectname = "NoHighlight"
+
+                block "portrait_button" {}
+            }
+        }
+    }
+
+    type portrait_event_duel = widget {
+
+        widget = {
+            size = { 930 490 }
+            parentanchor = bottom
+
+            icon = {
+                name = "hovered"
+                parentanchor = bottom|hcenter
+                size = { 40% 95% }
+                color = { 0.9 0.8 0.6 0.6 }
+
+                using = Background_Portrait_Glow
+
+                block "highlight_visible" {
+                    visible = no
+                }
+
+                state = {
+                    name = _show
+                    duration = 0.1
+                    using = Animation_Curve_Default
+                    alpha = 1
+                }
+
+                state = {
+                    name = _hide
+                    duration = 0.3
+                    using = Animation_Curve_Default
+                    alpha = 0
+                    delay = 0.05
+                }
+            }
+
+            portrait_button = {
+                size = { 930 490 }
+                using = portrait_base
+                parentanchor = hcenter|bottom
+
+                portrait_texture = "[Character.GetAnimatedPortrait('environment_event_standard', 'environment_event_standard', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+                background_texture = "gfx/portraits/portrait_transparent.dds"
+                texture = "gfx/portraits/portrait_transparent.dds"
+                mask = "gfx/portraits/portrait_mask_event.dds"
+                effectname = "NoHighlight"
+
+                block "portrait_button" {}
+            }
+        }
+    }
+
+    type portrait_event_small = widget {
+        size = { 125 160 }
+
+        icon = {
+            name = "hovered"
+            parentanchor = bottom|hcenter
+            size = { 100% 100% }
+            color = { 0.9 0.8 0.6 0.6 }
+
+            using = Background_Portrait_Glow
+
+            block "highlight_visible" {
+                visible = no
+            }
+
+            state = {
+                name = _show
+                duration = 0.1
+                using = Animation_Curve_Default
+                alpha = 1
+            }
+
+            state = {
+                name = _hide
+                duration = 0.3
+                using = Animation_Curve_Default
+                alpha = 0
+                delay = 0.05
+            }
+        }
+
+        portrait_shoulders = {
+            size = { 100% 100% }
+            blockoverride "portrait_glows" {}
+        }
+    }
+
+    type portrait_council = widget {
+        size = { 260 285 }
+
+        portrait_button = {
+            block "portrait_size"
+            {
+                size = { 260 285 }
+            }
+            parentanchor = bottom|hcenter
+            using = portrait_base
+
+            portrait_texture = "[Character.GetAnimatedPortrait('environment_council', 'camera_council', CouncilPositionType.GetPortraitAnimation, PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+            mask = "gfx/portraits/portrait_mask_council.dds"
+            effectname = "NoHighlight"
+
+            block "mask" {
+                mask = "gfx/portraits/portrait_mask_council.dds"
+            }
+        }
+
+        #portrait unknown glow
+        button = {
+            name = "portrait_unknown_council_glow"
+            visible = "[Not(Character.IsValid)]"
+            parentanchor = center
+            position = { 2 -37 }
+            gfxtype = framedbuttongfx
+            effectname = "NoHighlight"
+            texture = "gfx/portraits/unknown_portraits/button_unknown_small.dds"
+            size = { 239 312 }
+            framesize = { 564 780 }
+            upframe = 1
+            overframe = 2
+
+            block "glow_visible" {
+
+                visible = "[Not(Character.IsValid)]"
+
+            }
+
+            block "onclick" {}
+        }
+    }
+
+    type portrait_war_overview = margin_widget {
+        size = { 240 300 }
+        allow_outside = yes
+
+        margin = { 3 3 }
+
+        widget = {
+            using = Portrait_Background_Glows
+            size = { 320 380 }
+
+            alwaystransparent = yes
+            parentanchor = bottom|hcenter
+        }
+
+
+        portrait_button = {
+            size = { 420 632 }
+            parentanchor = bottom|hcenter
+            using = portrait_base
+
+            portrait_texture = "[Character.GetAnimatedPortrait('environment_war_overview', 'camera_war_overview', Select_CString(WarParticipantItem.IsAttacker, 'war_attacker', 'war_defender'), PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+            mask = "gfx/portraits/portrait_mask_torso.dds"
+            effectname = "NoHighlight"
+
+            block "portrait_button" {}
+
+            block "portrait_transformation"
+            {
+                portrait_scale = { 1 1 }
+            }
+
+            highlight_icon = {
+                name = "prison_bars"
+                visible = "[Character.IsImprisoned]"
+                size = { 100% 80% }
+                position = { 30 160 }
+
+                effectname = "NoHighlight"
+                texture = "gfx/portraits/portrait_prison_body.dds"
+
+                modify_texture = {
+                    name = "mask"
+                    texture = "gfx/portraits/portrait_mask_character_view.dds"
+                    spriteType = Corneredstretched
+                    blend_mode = alphamultiply
+                }
+            }
+        }
+    }
+
+    ### Bottom left HUD portrait
+    type portrait_hud = portrait_button {
+        name = "tutorial_highlight_bottom_left_portrait_button"
+        visible = "[Not(GetVariableSystem.Exists( 'lifestyle_open' ))]"
+        size = { 280 280 }
+
+        gfxtype = portraitbuttongfx
+        shaderfile = "gfx/FX/jomini/gui_portrait.shader"
+        effectname = "NoHighlight"
+
+        state = {
+            name = _mouse_enter
+            on_start = "[Character.OnMouseEnter]"
+            scale = 1.05
+            using = Animation_Curve_Default
+            duration = 0.05
+        }
+
+        state = {
+            name = _mouse_leave
+            on_start = "[Character.OnMouseLeave]"
+            using = Animation_Curve_Default
+            duration = 0.05
+            scale = 1
+        }
+
+        state = {
+            name = _mouse_release
+            start_sound = {
+                soundeffect = "event:/SFX/UI/Character/sfx_ui_character_portrait_select"
+            }
+        }
+
+        onclick = "[DefaultOnCharacterClick(Character.GetID)]"
+        onrightclick = "[DefaultOnCharacterRightClick(Character.GetID)]"
+        button_ignore = none
+
+        clicksound = "event:/SFX/UI/Character/sfx_ui_character_portrait_select"
+        oversound = "event:/SFX/UI/Character/sfx_ui_character_portrait_pointer_over"
+
+        portrait_texture = "[Character.GetAnimatedPortrait('environment_hud', 'camera_shoulders', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+        background_texture = "gfx/portraits/portrait_transparent.dds"
+        texture = "gfx/portraits/portrait_transparent.dds"
+        mask = "gfx/portraits/portrait_mask_blank.dds"
+
+        highlight_icon = {
+            name = "prison_bars"
+            visible = "[Character.IsImprisoned]"
+            size = { 100% 100% }
+            effectname = "NoHighlight"
+            texture = "gfx/portraits/portrait_prison_shoulders.dds"
+            position = { 25 0 }
+
+            modify_texture = {
+                name = "mask"
+                texture = "gfx/portraits/portrait_mask_head.dds"
+                spriteType = Corneredstretched
+                blend_mode = alphamultiply
+                rotate_uv = 180
+            }
+        }
+
+        using = tooltip_es
+        # tooltip_enabled = "[Not(IsInteractionMenuOpenForCharacter(Character.GetID))]"
+        tooltip_enabled = no
+
+        tooltipwidget = {
+            cooltip_type = {
+                blockoverride "interaction_info"
+                {
+                    text = "CHARACTER_TOOLTIP_INSTRUCTION"
+                }
+            }
+        }
+
+        tooltip_offset = { -10 0 }
+        tooltip_verticalbehavior = slide
+        tooltip_horizontalbehavior = mirror
+    }
+
+    ### Lifestyles portrait
+    type portrait_lifestyles = portrait_button {
+        size = { 500 1000 }
+        alwaystransparent = "[Not(Lifestyle.IsValid)]"
+        effectname = "NoHighlight"
+        tooltip_enabled = no
+
+        using = portrait_base
+
+        onclick = "[DefaultOnCharacterClick(Character.GetID)]"
+
+        portrait_texture = "[Character.GetAnimatedPortrait('environment_body', 'camera_lifestyles', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+        mask = "gfx/portraits/portrait_mask_blank.dds"
+
+        state ={
+            name = _show
+            using = Animation_Curve_Default
+
+            duration = 0.15
+            alpha = 1
+        }
+
+        state = {
+            name = _hide
+            using = Animation_Curve_Default
+
+            duration = 0.15
+            alpha = 0
+        }
+
+        background = {
+            name = "hovered"
+            visible = "[Character.IsHovered]"
+            using = Background_Portrait_Glow
+            color = { 0.9 0.8 0.6 0.6 }
+        }
+    }
+
+    type portrait_head_small_relationship = widget {
+        size = { 85 90 }
+
+        background = {
+            using = Background_Area_Solid
+
+            modify_texture = {
+                texture = "gfx/interface/component_masks/mask_fade_vertical.dds"
+                blend_mode = alphamultiply
+                alpha = 0.2
+                mirror = vertical
+            }
+        }
+
+        background = {
+            block "empty_character" {}
+            visible = "[Not( Character.HasLandedTitles )]"
+            texture = "gfx/portraits/portrait_frame.dds"
+            using = Color_Grey
+            margin = { -4 -4 }
+            alpha = 0.4
+        }
+
+        widget = {
+            size = { 100% 100% }
+            using = Portrait_Background_Glows
+
+            block "empty_character" {}
+        }
+
+        portrait_button = {
+            parentanchor = bottom|hcenter
+            size = { 80 100 }
+            using = portrait_base
+
+            block "portrait_texture"
+            {
+                portrait_texture = "[Character.GetPortrait('environment_head', 'camera_head', 'idle', PdxGetWidgetScreenSize(PdxGuiWidget.Self))]"
+            }
+
+            mask = "gfx/portraits/portrait_mask_head_small.dds"
+            effectname = "NoHighlight"
+
+            highlight_icon = {
+                name = "prison_bars"
+                visible = "[Character.IsImprisoned]"
+                size = { 80 88 }
+                parentanchor = bottom
+                effectname = "NoHighlight"
+                texture = "gfx/portraits/portrait_prison_head.dds"
+
+                modify_texture = {
+                    name = "mask"
+                    texture = "gfx/portraits/portrait_mask_head_small.dds"
+                    spriteType = Corneredstretched
+                    blend_mode = alphamultiply
+                }
+            }
+
+            block "portrait_button" {}
+        }
+
+        widget = {
+            name = "character_rank"
+            visible = "[Character.HasLandedTitles]"
+            size = { 100% 100% }
+
+            background = {
+                texture = "gfx/portraits/portrait_rank.dds"
+
+                margin_top = -4
+                margin_bottom = -3
+                margin_right = -4
+                margin_left = -3
+
+                framesize = { 196 194 }
+                frame = "[Character.GetPrimaryTitle.GetTierFrame]"
+            }
+        }
+
+        block "coa" {
+            coa_realm_tiny = {
+                visible = "[Character.HasLandedTitles]"
+                parentanchor = bottom|left
+                position = { 3 -2 }
+                scale = 0.85
+            }
+        }
+
+        widget = {
+            size = { 100% 100% }
+            visible = "[Not( Character.HasLandedTitles )]"
+            block "empty_character" {}
+
+            background = {
+                texture = "gfx/portraits/portrait_frame.dds"
+                using = Color_Grey
+                margin = { -4 -4 }
+                alpha = 0.4
+
+                modify_texture = {
+                    texture = "gfx/interface/component_masks/mask_fade_vertical.dds"
+                    blend_mode = alphamultiply
+                    mirror = vertical
+                }
+            }
+
+            background = {
+                visible = "[Character.IsHovered]"
+                texture = "gfx/portraits/portrait_frame.dds"
+                using = Color_Grey
+                alpha = 0.7
+                margin = { -4 -4 }
+            }
+        }
+
+        flowcontainer = {
+            visible = "[Character.IsValid]"
+            ignoreinvisible = yes
+            parentanchor = top|right
+
+            block "scripted_relation_status_icons"
+            {
+                using = Portrait_Relation_Icons_Character_Window
+            }
+
+            margin_right = 2
+
+            blockoverride "icon_size"
+            {
+                size = { 24 24 }
+            }
+
+            background = {
+                using = Background_Area_Dark
+                margin = { 2 2 }
+                alpha = 0.8
+
+                modify_texture = {
+                    texture = "gfx/interface/component_masks/mask_glow.dds"
+                    blend_mode = alphamultiply
+                }
+            }
+        }
+
+        widget = {
+            size = { 85 68 }
+            scissor = yes
+            parentanchor = bottom
+
+            flowcontainer = {
+                parentanchor = bottom|right
+                ignoreinvisible = yes
+                direction = vertical
+
+                margin = { 4 0 }
+                margin_bottom = 4
+
+                flowcontainer = {
+                    visible = "[Character.IsValid]"
+                    ignoreinvisible = yes
+                    direction = vertical
+                    parentanchor = right
+                    spacing = 1
+
+                    margin_right = 2
+
+                    background = {
+                        using = Background_Area_Dark
+                        margin = { 2 2 }
+                    }
+
+                    # sorted by priority, highest prio at the bottom
+                    block "status_icons" {
+
+                        icon = {
+                            name = "relation_icon"
+                            visible = "[LessThan_int32(Character.GetPlayerDynastyRelationFrame, '(int32)9')]"
+                            size = { 14 14 }
+
+                            texture = "gfx/interface/icons/portraits/relation_small.dds"
+                            framesize = { 28 28 }
+                            frame = "[Character.GetPlayerDynastyRelationFrame]"
+                            tooltip = "[Character.GetPlayerDynastyRelationTooltip]"
+                        }
+
+                        icon = {
+                            name = "incapable"
+                            visible = "[Character.IsIncapable]"
+                            size = { 14 14 }
+                            texture = "gfx/interface/icons/portraits/incapable_small.dds"
+                            tooltip = "trait_incapable"
+                        }
+
+                        block "inspiration_status_icons"
+                        {
+                            has_inspiration_status_icon = {
+                                size = { 14 14 }
+                                texture = "gfx/interface/icons/portraits/inspiration_small.dds"
+                            }
+
+                            has_completed_inspiration_status_icon = {
+                                size = { 14 14 }
+                                texture = "gfx/interface/icons/portraits/inspiration_complete_small.dds"
+                            }
+                        }
+
+                        icon = {
+                            name = "can_be_punished"
+                            visible = "[Character.CanBePunished]"
+                            size = { 14 14 }
+
+                            texture = "gfx/interface/icons/portraits/punishment_small.dds"
+                            tooltip = "[Character.PunishmentTooltip]"
+                        }
+
+                        icon = {
+                            name = "hook"
+                            visible = "[Character.PlayerHasHooksOrHookableSecrets]"
+                            size = { 14 14 }
+
+                            texture = "gfx/interface/icons/portraits/hook_secret_small.dds"
+                            framesize = { 28 28 }
+                            frame = "[Character.GetHookOrHookableSecretsFrame]"
+                            tooltip = "[Character.HookTooltip]"
+                        }
+
+                        icon = {
+                            name = "powerful_vassal"
+                            visible = "[Character.IsMyPowerfulVassal]"
+                            size = { 14 14 }
+
+                            texture = "gfx/interface/icons/portraits/powerful_vassal_small.dds"
+                            framesize = { 28 28 }
+                            frame = "[Character.GetPowerfulVassalFrame]"
+                            tooltip = "[Character.GetPowerfulVassalTooltip]"
+                        }
+
+                        icon = {
+                            name = "head_icon"
+                            visible = "[LessThan_int32(Character.GetDynastyHeadRelationFrame('(bool)yes'), '(int32)9')]"
+                            size = { 14 14 }
+
+                            texture = "gfx/interface/icons/portraits/relation_small.dds"
+                            framesize = { 28 28 }
+                            frame = "[Character.GetDynastyHeadRelationFrame('(bool)yes')]"
+                            tooltip = "[Character.GetDynastyHeadRelationTooltip]"
+                        }
+
+                        icon = {
+                            name = "playable_icon"
+                            visible = "[ObjectsEqual( Character.Self, GetPlayer.GetPlayerHeir )]"
+                            size = { 14 14 }
+                            texture = "gfx/interface/icons/portraits/heir_small.dds"
+                            tooltip = "[Character.GetPlayableFrameTooltip]"
+                        }
+                    }
+
+                    block "dead_icon"
+                    {
+                        icon = {
+                            name = "is_dead"
+                            visible = "[Character.IsDeadAndValid]"
+                            size = { 14 14 }
+
+                            texture = "[Character.GetDeathReasonIcon]"
+                            tooltip = "CHARACTER_DEAD_TOOLTIP"
+                        }
+                    }
+                }
+
+                block "opinion_box"
+                {
+                    portrait_opinion_small = {
+                        name = "tutorial_highlight_character_view_opinion_heir"
+                    }
+                }
+            }
+        }
+
+
+        # Portrait unknown glow
+        highlight_icon = {
+            name = "portrait_unknown_head_small_glow"
+            parentanchor = center
+            position = { 3 -9 }
+            gfxtype = framedbuttongfx
+            effectname = "NoHighlight"
+            texture = "gfx/portraits/unknown_portraits/button_unknown_head.dds"
+            size = { 80 100 }
+            framesize = { 384 480 }
+            upframe = 1
+            overframe = 2
+
+            block "glow_visible"
+            {
+                visible = "[Not(Character.IsValid)]"
+            }
+
+            block "glow_flip" {}
+
+            block "onclick" {}
+        }
+    }
+
+    ####################################
+    ########### ACCESSORIES ############
+    ####################################
+
+    ## Opinion box for portraits
+    type portrait_opinion = flowcontainer {
+        name = "tutorial_highlight_portrait_opinion"
+        visible = "[And(Character.IsValid, And(Character.IsAlive, Not(Character.IsLocalPlayer)))]"
+        ignoreinvisible = yes
+
+        background = {
+            name = "portrait_opinion_bg"
+            texture = "gfx/interface/component_tiles/solid_black_label.dds"
+            spritetype = Corneredtiled
+            spriteborder = { 20 20 }
+            margin = { 3 1 }
+            texture_density = 2
+        }
+
+        icon = {
+            block "dread_logic" {
+                visible = "[Character.ShouldShowDreadEffectIcon]"
+                frame = "[Character.GetPlayerDreadEffectIconFrame]"
+                tooltip = "[Character.GetPlayerDreadEffectTooltip]"
+            }
+            name = "dread"
+            size = { 20 20 }
+            texture = "gfx/interface/icons/portraits/dread_values.dds"
+            framesize = { 40 40 }
+        }
+
+        text_single = {
+            name = "tutorial_highlight_character_view_opinion"
+            visible = "[Character.IsValid]"
+            max_width = 45
+            align = nobaseline
+            margin = { 3 0 }
+            tooltipwidget = character_opinion_tooltip
+            using = tooltip_es
+            default_format = "#true_white"
+
+            block "opinion_text" {
+                text = "[Character.GetOpinionOf( GetPlayer )|=]"
+                fonttintcolor = "[Character.GetOpinionOfTint( GetPlayer )]"
+            }
+        }
+    }
+
+    type portrait_opinion_small = flowcontainer {
+        #name = "tutorial_highlight_portrait_opinion"
+        visible = "[And(Character.IsValid, And(Character.IsAlive, Not(Character.IsLocalPlayer)))]"
+        ignoreinvisible = yes
+        margin_right = 2
+
+        background = {
+            name = "portrait_opinion_bg"
+            texture = "gfx/interface/component_tiles/solid_black_label.dds"
+            spritetype = Corneredtiled
+            spriteborder = { 20 20 }
+            margin = { 2 2 }
+            texture_density = 2
+        }
+
+        icon = {
+            name = "dread"
+            visible = "[Character.ShouldShowDreadEffectIcon]"
+            size = { 16 16 }
+            texture = "gfx/interface/icons/portraits/dread_values.dds"
+            framesize = { 40 40 }
+            frame = "[Character.GetPlayerDreadEffectIconFrame]"
+            tooltip = "[Character.GetPlayerDreadEffectTooltip]"
+        }
+
+        text_single = {
+            visible = "[Character.IsValid]"
+            max_width = 45
+            align = nobaseline
+            fontsize = 13
+            margin = { 3 0 }
+
+            tooltipwidget = character_opinion_tooltip
+            using = tooltip_es
+            default_format = "#true_white"
+
+            block "opinion_text" {
+                text = "[Character.GetOpinionOf( GetPlayer )|=]"
+                fonttintcolor = "[Character.GetOpinionOfTint( GetPlayer )]"
+            }
+        }
+    }
+
+    type has_inspiration_status_icon = icon
+    {
+        name = "has_inspiration"
+        visible = "[Character.HasInspiration]"
+        texture = "gfx/interface/icons/portraits/inspiration.dds"
+        tooltip = "CHARACTER_HAS_INSPIRATION_TOOLTIP"
+    }
+
+    type has_completed_inspiration_status_icon = icon
+    {
+        name = "has_completed_inspiration"
+        visible = "[And( Character.HasCompletedAnInspiration, Not( Character.HasInspiration ) )]" # Has an inspiration takes priority
+        texture = "gfx/interface/icons/portraits/inspiration_complete.dds"
+        tooltip = "CHARACTER_HAS_COMPLETED_AN_INSPIRATION_TOOLTIP"
+    }
+
+    ## Status icons, shown in the bottom right on portraits
+    type portrait_status_icons_small = widget {
+        size = { 16 60 }
+        scissor = yes
+
+        flowcontainer = {
+            visible = "[Character.IsValid]"
+            ignoreinvisible = yes
+            direction = vertical
+            parentanchor = bottom
+            spacing = 1
+
+            background = {
+                using = Background_Area_Dark
+                margin = { 2 2 }
+            }
+
+            # sorted by priority, highest prio at the bottom
+            block "status_icons" {
+
+                block "scripted_relation_status_icons"
+                {
+                    using = Portrait_Relation_Icons_Small
+                }
+
+                icon = {
+                    name = "relation_icon"
+                    visible = "[LessThan_int32(Character.GetPlayerDynastyRelationFrame, '(int32)9')]"
+                    size = { 14 14 }
+
+                    texture = "gfx/interface/icons/portraits/relation_small.dds"
+                    framesize = { 28 28 }
+                    frame = "[Character.GetPlayerDynastyRelationFrame]"
+                    tooltip = "[Character.GetPlayerDynastyRelationTooltip]"
+                }
+
+                icon = {
+                    name = "incapable"
+                    visible = "[Character.IsIncapable]"
+                    size = { 14 14 }
+                    texture = "gfx/interface/icons/portraits/incapable_small.dds"
+                    tooltip = "trait_incapable"
+                }
+
+                block "inspiration_status_icons"
+                {
+                    has_inspiration_status_icon = {
+                        size = { 14 14 }
+                        texture = "gfx/interface/icons/portraits/inspiration_small.dds"
+                    }
+
+                    has_completed_inspiration_status_icon = {
+                        size = { 14 14 }
+                        texture = "gfx/interface/icons/portraits/inspiration_complete_small.dds"
+                    }
+                }
+
+                icon = {
+                    name = "can_be_punished"
+                    visible = "[Character.CanBePunished]"
+                    size = { 14 14 }
+
+                    texture = "gfx/interface/icons/portraits/punishment_small.dds"
+                    tooltip = "[Character.PunishmentTooltip]"
+                }
+
+                icon = {
+                    name = "hook"
+                    visible = "[Character.PlayerHasHooksOrHookableSecrets]"
+                    size = { 14 14 }
+
+                    texture = "gfx/interface/icons/portraits/hook_secret_small.dds"
+                    framesize = { 28 28 }
+                    frame = "[Character.GetHookOrHookableSecretsFrame]"
+                    tooltip = "[Character.HookTooltip]"
+                }
+
+                icon = {
+                    name = "powerful_vassal"
+                    visible = "[Character.IsMyPowerfulVassal]"
+                    size = { 14 14 }
+
+                    texture = "gfx/interface/icons/portraits/powerful_vassal_small.dds"
+                    framesize = { 28 28 }
+                    frame = "[Character.GetPowerfulVassalFrame]"
+                    tooltip = "[Character.GetPowerfulVassalTooltip]"
+                }
+
+                icon = {
+                    name = "head_icon"
+                    visible = "[LessThan_int32(Character.GetDynastyHeadRelationFrame('(bool)yes'), '(int32)9')]"
+                    size = { 14 14 }
+
+                    texture = "gfx/interface/icons/portraits/relation_small.dds"
+                    framesize = { 28 28 }
+                    frame = "[Character.GetDynastyHeadRelationFrame('(bool)yes')]"
+                    tooltip = "[Character.GetDynastyHeadRelationTooltip]"
+                }
+
+                icon = {
+                    name = "playable_icon"
+                    visible = "[ObjectsEqual( Character.Self, GetPlayer.GetPlayerHeir )]"
+                    size = { 14 14 }
+                    texture = "gfx/interface/icons/portraits/heir_small.dds"
+                    tooltip = "[Character.GetPlayableFrameTooltip]"
+                }
+            }
+
+            block "dead_icon"
+            {
+                icon = {
+                    name = "is_dead"
+                    visible = "[Character.IsDeadAndValid]"
+                    size = { 14 14 }
+
+                    texture = "[Character.GetDeathReasonIcon]"
+                    tooltip = "CHARACTER_DEAD_TOOLTIP"
+                }
+            }
+        }
+    }
+
+    type portrait_status_icons = flowcontainer {
+        ignoreinvisible = yes
+        visible = "[Character.IsValid]"
+
+        block "direction"
+        {
+            direction = vertical
+        }
+
+        # sorted by priority, highest prio at the bottom
+        block "status_icons" {
+
+            block "scripted_relation_status_icons"
+            {
+                using = Portrait_Relation_Icons
+            }
+
+            icon = {
+                name = "relation_icon"
+                visible = "[LessThan_int32(Character.GetPlayerDynastyRelationFrame, '(int32)9')]"
+                size = { 20 20 }
+
+                texture = "gfx/interface/icons/portraits/relation.dds"
+                framesize = { 40 40 }
+                frame = "[Character.GetPlayerDynastyRelationFrame]"
+                tooltip = "[Character.GetPlayerDynastyRelationTooltip]"
+            }
+
+            icon = {
+                name = "incapable"
+                visible = "[Character.IsIncapable]"
+                size = { 20 20 }
+                texture = "gfx/interface/icons/portraits/incapable.dds"
+                tooltip = "CHARACTER_INCAPABLE_TOOLTIP"
+            }
+
+            block "inspiration_status_icons"
+            {
+                has_inspiration_status_icon = {
+                    size = { 20 20 }
+                }
+                has_completed_inspiration_status_icon = {
+                    size = { 20 20 }
+                }
+            }
+
+            icon = {
+                name = "can_be_punished"
+                visible = "[Character.CanBePunished]"
+                size = { 20 20 }
+
+                texture = "gfx/interface/icons/portraits/punishment.dds"
+                tooltip = "[Character.PunishmentTooltip]"
+            }
+
+            icon = {
+                name = "hook"
+                visible = "[Character.PlayerHasHooksOrHookableSecrets]"
+                size = { 20 20 }
+
+                texture = "gfx/interface/icons/portraits/hook_secret.dds"
+                framesize = { 40 40 }
+                frame = "[Character.GetHookOrHookableSecretsFrame]"
+                tooltip = "[Character.HookTooltip]"
+            }
+
+            icon = {
+                name = "liege_icon"
+                visible = "[And( ObjectsEqual( GetPlayer.GetLiege, Character.Self ) , Not( GetPlayer.IsIndependentRuler ) ) ]"
+                size = { 20 20 }
+
+                texture = "gfx/interface/icons/portraits/liege.dds"
+                tooltip = "FRAME_RELATION_MY_LIEGE"
+            }
+
+            icon = {
+                name = "powerful_vassal"
+                visible = "[Character.IsMyPowerfulVassal]"
+                size = { 20 20 }
+
+                texture = "gfx/interface/icons/portraits/powerful_vassal.dds"
+                framesize = { 40 40 }
+                frame = "[Character.GetPowerfulVassalFrame]"
+                tooltip = "[Character.GetPowerfulVassalTooltip]"
+            }
+
+            icon = {
+                    name = "head_icon"
+                    visible = "[LessThan_int32(Character.GetDynastyHeadRelationFrame('(bool)yes'), '(int32)9')]"
+                    size = { 20 20 }
+
+                    texture = "gfx/interface/icons/portraits/relation.dds"
+                    framesize = { 40 40 }
+                    frame = "[Character.GetDynastyHeadRelationFrame('(bool)yes')]"
+                    tooltip = "[Character.GetDynastyHeadRelationTooltip]"
+            }
+
+            icon = {
+                name = "playable_icon"
+                visible = "[ObjectsEqual( Character.Self, GetPlayer.GetPlayerHeir )]"
+                size = { 20 20 }
+                texture = "gfx/interface/icons/portraits/heir.dds"
+                tooltip = "[Character.GetPlayableFrameTooltip]"
+            }
+        }
+
+        block "dead_icon"
+        {
+            icon = {
+                name = "is_dead"
+                visible = "[Character.IsDeadAndValid]"
+                size = { 20 20 }
+
+                texture = "[Character.GetDeathReasonIcon]"
+                tooltip = "CHARACTER_DEAD_TOOLTIP"
+            }
+        }
+    }
+}
+
+######################################################
+##################### TEMPLATES ######################
+######################################################
+
+## BASE TEMPLATE
+
+template portrait_base
+{
+    pop_out = no
+    block "grayscale" {
+        grayscale = "[Not(Character.IsAlive)]"
+    }
+
+    gfxtype = portraitbuttongfx
+    shaderfile = "gfx/FX/jomini/gui_portrait.shader"
+
+    intersectionmask = no
+
+    background_texture = "gfx/portraits/portrait_transparent.dds"
+    texture = "gfx/portraits/portrait_transparent.dds"
+
+    clicksound = "event:/SFX/UI/Character/sfx_ui_character_portrait_select"
+    oversound = "event:/SFX/UI/Character/sfx_ui_character_portrait_pointer_over"
+
+    block "portrait_button_template_onmouseenter"
+    {
+        state = {
+            name = _mouse_enter
+            on_start = "[Character.OnMouseEnter]"
+        }
+    }
+    block "portrait_button_template_onmouseleave"
+    {
+        state = {
+            name = _mouse_leave
+            on_start = "[Character.OnMouseLeave]"
+        }
+    }
+
+    block "portrait_button_template_onclick"
+    {
+        onclick = "[DefaultOnCharacterClick(Character.GetID)]"
+    }
+
+    block "portrait_button_template_onrightclick"
+    {
+        onrightclick = "[DefaultOnCharacterRightClick(Character.GetID)]"
+        button_ignore = none
+    }
+
+    filter_mouse = right
+
+    block "portrait_button_template_tooltip"
+    {
+        tooltip_enabled = "[Not(IsInteractionMenuOpenForCharacter(Character.GetID))]"
+
+        tooltipwidget = {
+            cooltip_type = {
+                blockoverride "interaction_info" {
+                    text = "CHARACTER_TOOLTIP_INSTRUCTION"
+                }
+            }
+        }
+    }
+
+    using = tooltip_es
+    tooltip_offset = { 0 0 }
+    tooltip_verticalbehavior = slide
+    tooltip_horizontalbehavior = mirror
+
+    block "portrait_transformation"
+    {
+        portrait_scale = { 1.0 1.0 }
+        portrait_offset = { 0.0 0.0 }
+    }
+}
+
+template Portrait_Background_Glows
+{
+    block "portrait_glow"
+    {
+        # Is Local Player
+        block "glow_local_player"
+        {
+            background = {
+                visible = "[And(Character.IsLocalPlayer, Not(Character.IsHovered))]"
+                using = Background_Portrait_Glow
+                color = { 0.5 0.6 0.7 0.6 }
+            }
+        }
+
+        block "glow_other_player"
+        {
+            # Is Other Player
+            background = {
+                visible = "[And(Character.IsOtherPlayer, Not(Character.IsHovered))]"
+                using = Background_Portrait_Glow
+                color = { 0.8 0.4 0.55 0.6 }
+            }
+        }
+
+        block "glow_selected"
+        {
+            background = {
+                name = "selected"
+                using = Background_Portrait_Glow
+                color = { 0.8 0.7 0.5 0.6 }
+
+                block "glow_selected_visible"
+                {
+                    visible = "[Character.IsSelected]"
+                }
+            }
+        }
+
+        block "glow_hovered"
+        {
+            background = {
+                name = "hovered"
+                visible = "[Character.IsHovered]"
+                using = Background_Portrait_Glow
+                color = { 0.9 0.8 0.6 0.6 }
+            }
+        }
+    }
+}
+
+template Background_Portrait_Glow
+{
+    texture = "gfx/portraits/portrait_glow.dds"
+}
+
+template Portrait_Relation_Icon_Normal_Size
+{
+    size = { 20 20 }
+    framesize = { 40 40 }
+
+    visible = "[ScriptedRelation.HasRelationBetween( GetPlayer, Character.Self )]"
+
+    tooltipwidget = {
+        scripted_relation_tooltip = {
+            blockoverride "description_text"
+            {
+                text = "[GetScriptedRelationTooltip( ScriptedRelation, GetPlayer, Character )]"
+            }
+        }
+    }
+}
+
+template Portrait_Relation_Icon_Small_Size
+{
+    size = { 14 14 }
+    framesize = { 28 28 }
+
+    visible = "[ScriptedRelation.HasRelationBetween( GetPlayer, Character.Self )]"
+
+    tooltipwidget = {
+        scripted_relation_tooltip = {
+            blockoverride "description_text"
+            {
+                text = "[GetScriptedRelationTooltip( ScriptedRelation, GetPlayer, Character )]"
+            }
+        }
+    }
+}
+
+types portrait_icons
+{
+    type scripted_relation_tooltip = container
+    {
+        alwaystransparent = no
+
+        object_tooltip_pop_out = {
+            blockoverride "title_text" {
+                margin = { 0 8 }
+                text = "[ScriptedRelation.GetName]"
+            }
+
+            blockoverride "concept_link" {
+                text = "[relation|E]"
+            }
+        }
+    }
+
+    # Normal size icons
+    type lover_relation_icon = icon
+    {
+        name = "lover"
+
+        datacontext = "[GetRelation( 'lover' )]"
+
+        texture = "gfx/interface/icons/portraits/lover_soulmate.dds"
+        frame = 1
+
+        block "icon_template" {
+            using = Portrait_Relation_Icon_Normal_Size
+        }
+    }
+
+    type friend_relation_icon = icon
+    {
+        name = "friend"
+
+        datacontext = "[GetRelation( 'friend' )]"
+
+        texture = "gfx/interface/icons/portraits/friend_bestfriend.dds"
+        frame = 1
+
+        block "icon_template" {
+            using = Portrait_Relation_Icon_Normal_Size
+        }
+    }
+
+    type rival_relation_icon = icon
+    {
+        name = "rival"
+
+        datacontext = "[GetRelation( 'rival' )]"
+
+        texture = "gfx/interface/icons/portraits/rival_nemesis.dds"
+        frame = 1
+
+        block "icon_template" {
+            using = Portrait_Relation_Icon_Normal_Size
+        }
+    }
+
+    type soulmate_relation_icon = icon
+    {
+        name = "soulmate"
+
+        datacontext = "[GetRelation( 'soulmate' )]"
+
+        texture = "gfx/interface/icons/portraits/lover_soulmate.dds"
+        frame = 2
+
+        block "icon_template" {
+            using = Portrait_Relation_Icon_Normal_Size
+        }
+    }
+
+    type best_friend_relation_icon = icon
+    {
+        name = "best_friend"
+
+        datacontext = "[GetRelation( 'best_friend' )]"
+
+        texture = "gfx/interface/icons/portraits/friend_bestfriend.dds"
+        frame = 2
+
+        block "icon_template" {
+            using = Portrait_Relation_Icon_Normal_Size
+        }
+    }
+
+    type nemesis_relation_icon = icon
+    {
+        name = "nemesis"
+
+        datacontext = "[GetRelation( 'nemesis' )]"
+
+        texture = "gfx/interface/icons/portraits/rival_nemesis.dds"
+        frame = 2
+
+        block "icon_template" {
+            using = Portrait_Relation_Icon_Normal_Size
+        }
+    }
+
+    # Small size icons
+    type lover_relation_icon_small = icon
+    {
+        name = "lover"
+
+        datacontext = "[GetRelation( 'lover' )]"
+
+        texture = "gfx/interface/icons/portraits/lover_soulmate_small.dds"
+        frame = 1
+
+        using = Portrait_Relation_Icon_Small_Size
+    }
+
+    type friend_relation_icon_small = icon
+    {
+        name = "friend"
+
+        datacontext = "[GetRelation( 'friend' )]"
+
+        texture = "gfx/interface/icons/portraits/friend_bestfriend_small.dds"
+        frame = 1
+
+        using = Portrait_Relation_Icon_Small_Size
+    }
+
+    type rival_relation_icon_small = icon
+    {
+        name = "rival"
+
+        datacontext = "[GetRelation( 'rival' )]"
+
+        texture = "gfx/interface/icons/portraits/rival_nemesis_small.dds"
+        frame = 1
+
+        using = Portrait_Relation_Icon_Small_Size
+    }
+
+    type soulmate_relation_icon_small = icon
+    {
+        name = "soulmate"
+
+        datacontext = "[GetRelation( 'soulmate' )]"
+
+        texture = "gfx/interface/icons/portraits/lover_soulmate_small.dds"
+        frame = 2
+
+        using = Portrait_Relation_Icon_Small_Size
+    }
+
+    type best_friend_relation_icon_small = icon
+    {
+        name = "best_friend"
+
+        datacontext = "[GetRelation( 'best_friend' )]"
+
+        texture = "gfx/interface/icons/portraits/friend_bestfriend_small.dds"
+        frame = 2
+
+        using = Portrait_Relation_Icon_Small_Size
+    }
+
+    type nemesis_relation_icon_small = icon
+    {
+        name = "nemesis"
+
+        datacontext = "[GetRelation( 'nemesis' )]"
+
+        texture = "gfx/interface/icons/portraits/rival_nemesis_small.dds"
+        frame = 2
+
+        using = Portrait_Relation_Icon_Small_Size
+    }
+}
+
+template Portrait_Relation_Icons
+{
+    lover_relation_icon = {}
+    friend_relation_icon = {}
+    rival_relation_icon = {}
+    soulmate_relation_icon = {}
+    best_friend_relation_icon = {}
+    nemesis_relation_icon = {}
+}
+
+template Portrait_Relation_Icons_Small
+{
+    lover_relation_icon_small = {}
+    friend_relation_icon_small = {}
+    rival_relation_icon_small = {}
+    soulmate_relation_icon_small = {}
+    best_friend_relation_icon_small = {}
+    nemesis_relation_icon_small = {}
+}
+
+template Portrait_Relation_Icons_Character_Window
+{
+    lover_relation_icon = {
+        blockoverride "icon_template"
+        {
+            using = Character_Window_Relation_Icon
+        }
+    }
+    friend_relation_icon = {
+        blockoverride "icon_template"
+        {
+            using = Character_Window_Relation_Icon
+        }
+    }
+    rival_relation_icon = {
+        blockoverride "icon_template"
+        {
+            using = Character_Window_Relation_Icon
+        }
+    }
+    soulmate_relation_icon = {
+        blockoverride "icon_template"
+        {
+            using = Character_Window_Relation_Icon
+        }
+    }
+    best_friend_relation_icon = {
+        blockoverride "icon_template"
+        {
+            using = Character_Window_Relation_Icon
+        }
+    }
+    nemesis_relation_icon = {
+        blockoverride "icon_template"
+        {
+            using = Character_Window_Relation_Icon
+        }
+    }
+}

--- a/mod/HidePlayers/gui/shared/portraits.gui
+++ b/mod/HidePlayers/gui/shared/portraits.gui
@@ -1827,16 +1827,6 @@ template Portrait_Background_Glows
             }
         }
 
-        block "glow_other_player"
-        {
-            # Is Other Player
-            background = {
-                visible = "[And(Character.IsOtherPlayer, Not(Character.IsHovered))]"
-                using = Background_Portrait_Glow
-                color = { 0.8 0.4 0.55 0.6 }
-            }
-        }
-
         block "glow_selected"
         {
             background = {


### PR DESCRIPTION
Added `portraits.gui` and removed the `block "glow_other_player"` remove the purple glow around other player characters.
Closes #2 